### PR TITLE
Added CORS Policy to S3 for manifest request

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -98,6 +98,22 @@ resources:
     DistBucket:
       Type: AWS::S3::Bucket
       DeletionPolicy: Delete
+      Properties:
+        CorsConfiguration:
+          CorsRules:
+            - AllowedHeaders:
+                - "*"
+              AllowedMethods: 
+                - "GET"
+              AllowedOrigins:
+                - Fn::Join:
+                    - ''
+                    - - https://
+                      - Ref: ApiGatewayRestApi
+                      - .execute-api.
+                      - Ref: AWS::Region
+                      - .amazonaws.com
+              MaxAge: 3000
 
   Outputs:
     ApiGatewayRestApi:


### PR DESCRIPTION
# What did you impliment
Added CORS policy to the S3 Bucket for GET Access for solely the lambda

Closes Issue #1 

# How did you implement it:
Added a rule to the Resources section in the `serverless yml`

# How can we verify it:
Run through the deployment scripts as documented in the `readme`, navigate to the deployed API Gateway URL in chrome or firefox, open the "Development Tools" tab, and the CORS error for the manifest should no longer exist.

Is this ready for review?: YES
Is it a breaking change?: NO