### PR TITLE
Added region to S3 Bucket Url for non us-east-1

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -18,12 +18,16 @@ provider:
     APP_DIST_URL:
       Fn::Join:
         - ''
-        - - https://s3.amazonaws.com/
+        - - https://s3-
+          - Ref: AWS::Region
+          - .amazonaws.com/
           - Ref: DistBucket
     APP_PUBLIC_URL:
       Fn::Join:
         - ''
-        - - https://s3.amazonaws.com/
+        - - https://s3-
+          - Ref: AWS::Region
+          - .amazonaws.com/
           - Ref: DistBucket
     APIGATEWAY_URL:
       Fn::Join:


### PR DESCRIPTION
# What did you impliment
Added region to any S3 URLs (including `us-east-1`). As to why, this is described in the [AWS Documentation on S3 Bucket creation](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html#create-bucket-intro)

Closes Issue #3 

# How did you implement it:
Added the region to the provider environment variables section for the S3 Urls in the `serverless yml`

# How can we verify it:
Run through the deployment scripts as documented in the `readme`, except deploy to region other than `us-east-1`, e.g. `serverless deploy --region us-east-2 --stage dev`, then navigate to the deployed API Gateway URL in chrome or firefox. The static content should then load as expected.

Is this ready for review?: YES
Is it a breaking change?: NO